### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -78,6 +78,8 @@ jobs:
   run-tests:
     needs: create-version-pr-or-release
     if: needs.create-version-pr-or-release.outputs.should-deploy == 'true'
+    permissions:
+      contents: none
     uses: ./.github/workflows/test.yaml
     secrets: inherit
   deploy-to-staging:


### PR DESCRIPTION
Potential fix for [https://github.com/squarebtech/github-actions-course-demo/security/code-scanning/4](https://github.com/squarebtech/github-actions-course-demo/security/code-scanning/4)

To fix the problem, we need to add a permissions block to the `run-tests` job that explicitly limits the permissions of the GITHUB_TOKEN to the minimum required for the task. Since the `run-tests` job uses a separate workflow (`test.yaml`) and does not directly perform repository operations (e.g., content reading or writing), the `permissions` block should ideally set all permissions to `none`, unless specific permissions are required.

Steps to implement the fix:
1. Add a `permissions` block to the `run-tests` job.
2. Set the permissions explicitly to `none` unless additional permissions are required by the test workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
