### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -9,6 +9,9 @@ concurrency:
 
 jobs:
   create-version-pr-or-release:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     outputs:
       should-deploy: ${{ steps.changesets.outputs.hasChangesets == 'false' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-{{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,10 @@
 name: Test
 on:
   workflow_call:
+permissions:
+  contents: read
+  id-token: write
+  actions: read
 
 jobs:
   test-and-build:


### PR DESCRIPTION
Potential fix for [https://github.com/squarebtech/github-actions-course-demo/security/code-scanning/3](https://github.com/squarebtech/github-actions-course-demo/security/code-scanning/3)

To fix the issue, add an explicit `permissions` block to the workflow. This block should define the least privileges required for the workflow to function properly. Since the workflow primarily interacts with repository contents, such as checking out code and uploading artifacts, the `contents: read` permission should suffice for most steps. Certain steps, like reporting test coverage or sending Slack messages, might require additional permissions, such as `contents: write` or permissions related to secrets.

The `permissions` key can be added at the root of the workflow to apply to all jobs or at the job level for more granular control. In this case, we'll add it at the root level to keep the configuration concise while ensuring adequate restrictions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
